### PR TITLE
Fix

### DIFF
--- a/Test/MyTest.cs
+++ b/Test/MyTest.cs
@@ -47,7 +47,7 @@ namespace Test {
 
             await helper.WaitUntilConnectedAsync();
 
-            var producer = helper.Broker.GetTestProducer("data");
+            var producer = helper.Broker.GetTestProducer("my-topic");
             await producer.ProduceAsync(new MyMessageType() { LastMessage = 6 });
 
             await helper.WaitUntilAllMessagesAreConsumedAsync();

--- a/Test/MyTest.cs
+++ b/Test/MyTest.cs
@@ -26,7 +26,7 @@ namespace Test {
     public class MyTest {
         [Test]
         public async Task Test1() {
-            WebApplicationFactory<Startup> factory = new WebApplicationFactory<Startup>().WithWebHostBuilder(
+            using WebApplicationFactory<Startup> factory = new WebApplicationFactory<Startup>().WithWebHostBuilder(
                 builder => {
                     builder.ConfigureTestServices(
                         services => {
@@ -51,7 +51,6 @@ namespace Test {
             await producer.ProduceAsync(new MyMessageType() { LastMessage = 6 });
 
             await helper.WaitUntilAllMessagesAreConsumedAsync();
-            await helper.WaitUntilOutboxIsEmptyAsync(new CancellationToken());
 
             HttpResponseMessage response_2 = await client.GetAsync("/");
             string response_message_2 = await response_2.Content.ReadAsStringAsync();


### PR DESCRIPTION
The first commit is the actual fix for the consumer not being called: you were just using different topic names in producer and consumer.

The second commit is just a suggestion as I saw the missing `using` of the factory that causes the tests process to not exit properly and the call to `WaitUntilOutboxIsEmptyAsync` is just not needed (in general, not only in this case, since that's implicitly called by `WaitUntilAllMessagesAreConsumedAsync`).